### PR TITLE
supported more css units

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -172,7 +172,15 @@ var EXTENDED_COLOR_KEYWORDS = {
 }
 
 var LENGTH_REGEXP = /^[-+]?[0-9]*\.?[0-9]+(.*)$/
-var SUPPORT_CSS_UNIT = ['pt']
+// @todo:
+// font-relative lengths: em, ex, ch, ic
+// viewport-relative lengths: vi, vb
+// https://drafts.csswg.org/css-values/#lengths
+var SUPPORT_CSS_UNIT = [
+  'rem',
+  'vw', 'vh', 'vmin', 'vmax',
+  'cm', 'mm', 'q', 'in', 'pt', 'pc'
+]
 
 /**
  * the values above is valid


### PR DESCRIPTION
Support more CSS units without native update.

Three updates together:

1. `css-units` branch in `weexteam/weex-styler`
2. `weex-next` branch in `weexteam/weex-vue-loader`
3. `jsfm-feature-css-units` in `jinjiang/weex`

How it works: CSS value `100rem` in `<style>` will be transformed into `"100rem"` by `weex-styler` and then `100 * CSS_UNIT.REM` by `weex-vue-loader`. At the same time define global variable `CSS_UNIT` in JS Framework. So it works.