### PR TITLE
Emit not support style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 coverage
 .DS_Store
+.idea

--- a/index.js
+++ b/index.js
@@ -80,6 +80,7 @@ function parse(code, done) {
             if (subResult.log) {
               subResult.log.line = declaration.position.start.line
               subResult.log.column = declaration.position.start.column
+              subResult.log.selectors = rule.selectors.join(', ')
               ruleLog.push(subResult.log)
             }
           })

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -172,7 +172,7 @@ var EXTENDED_COLOR_KEYWORDS = {
 }
 
 var LENGTH_REGEXP = /^[-+]?\d*\.?\d+(\S*)$/
-var SUPPORT_CSS_UNIT = ['pt', 'wx']
+var SUPPORT_CSS_UNIT = ['pt', 'wx', 'px']
 
 /**
  * the values below is valid

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -517,7 +517,8 @@ var PROP_NAME_GROUPS = {
     fontStyle: genEnumValidator(['normal', 'italic']),
     fontWeight: genEnumValidator(['normal', 'bold', '100', '200', '300', '400', '500', '600', '700', '800', '900']),
     textDecoration: genEnumValidator(['none', 'underline', 'line-through']),
-    textAlign: genEnumValidator(['left', 'center', 'right'])
+    textAlign: genEnumValidator(['left', 'center', 'right']),
+    lineHeight: LENGTH_VALIDATOR
   },
   transition: {
     transitionProperty: TRANSITION_PROPERTY_VALIDATOR,


### PR DESCRIPTION
Support show not supported style in [weex-vue-loader](https://github.com/weexteam/weex-vue-loader)
Two updates together:
- `style-validate` branch in luxp/weex-styler
- `style-validate` branch in luxp/weex-vue-loader