### PR TITLE
Fix if prop is equal to transition

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ function parse(code, done) {
 
               // merge style
               Object.keys(ruleResult).forEach(function (prop) {
-                if (prop.indexOf('transition') === 0) { // handle transition
+                if (prop.indexOf('transition') === 0 && prop !== 'transition') { // handle transition
                   var realProp = prop.replace('transition', '')
                   realProp = realProp[0].toLowerCase() + realProp.slice(1)
                   jsonStyle['@TRANSITION'] = jsonStyle['@TRANSITION'] || {}


### PR DESCRIPTION
If `prop` value was `transition` then you will get:
```
ERROR in ./node_modules/weex-vue-loader/lib/style-loader.js!./node_modules/weex-vue-loader/lib/style-rewriter.js?id=data-v-55edf017!./node_modules/weex-vue-loader/lib/selector.js?type=styles&index=0!./resources/assets/js/components/layout/App.vue
    Module build failed: TypeError: Cannot read property 'toLowerCase' of undefined
```
As the script would try to make lowercase of undefined. I happens because `transition` is being replaced with nothing and `realProp` will become empty string. If it is empty string then you cannot get first element of it because it will be undefined.